### PR TITLE
setting configurable upper honking limit

### DIFF
--- a/src/components/Bubble.tsx
+++ b/src/components/Bubble.tsx
@@ -34,11 +34,35 @@ const images: Images = {
   },
 }
 
-const Bubble: React.FunctionComponent<BubbleProps> = ({ value, row, col, onPress }) => {
-  const honker: HTMLAudioElement = new Audio(`${process.env.PUBLIC_URL}/honk.mp3`)
+const maximumHonkingLevel = 4
 
+class HonkMother {
+  maxHonkers: number
+
+  currentHonker: number
+
+  honkers: Array<HTMLAudioElement>
+
+  constructor(maximumHonking: number) {
+    this.maxHonkers = maximumHonking
+    this.honkers = []
+    this.currentHonker = 0
+    for (let i = 0; i < maximumHonking; i++) {
+      this.honkers.push(new Audio(`${process.env.PUBLIC_URL}/honk.mp3`))
+    }
+  }
+
+  honkMe(): void {
+    this.honkers[this.currentHonker % this.maxHonkers].play()
+    this.currentHonker += 1
+  }
+}
+
+const HonkTimeFunZone: HonkMother = new HonkMother(maximumHonkingLevel)
+
+const Bubble: React.FunctionComponent<BubbleProps> = ({ value, row, col, onPress }) => {
   const handlePress = () => {
-    honker.play()
+    HonkTimeFunZone.honkMe()
     onPress(row, col)
   }
 


### PR DESCRIPTION
This PR creates a hard mximum level of honking.  Earlier honking implementations created a honker per button.  This change creates a manager class `HonkMother` that configures and encapsulates all honking.  With our `HonkTimeFunZone` singleton each bubble can achieve performant honking while maintaining appropriate multi-honking behavior.

User acceptance testing shows this branch is **just as annoying** as the current build on master, but should lower the number of server calls for the honker.